### PR TITLE
HOTFIX - Can disallow empty values

### DIFF
--- a/src/json-template.js
+++ b/src/json-template.js
@@ -7,6 +7,7 @@ var _ = require('lodash');
  * @param  {string} templateString JSON template as a string
  * @param  {object} options
  *  strictMode: if true, throws an error if a key is missing
+ *  disallowEmpty: if true, throws an error if a value is empty
  *  mapper: function to execute on each tag
  * @return {function} function(data): string
  */
@@ -22,6 +23,10 @@ module.exports = function(templateString, options) {
 
       if (_.isUndefined(value) && options.strictMode) {
         throw new Error('Missing key `' + _.trim(key) + '`');
+      }
+
+      if (_.isEmpty(_.trim(value)) && options.disallowEmpty) {
+        throw new Error('Empty value for key `' + _.trim(key) + '`');
       }
 
       return JSON.stringify(value || tag);

--- a/src/json-template.test.js
+++ b/src/json-template.test.js
@@ -56,6 +56,22 @@ describe('valid-json-template', function() {
     });
   });
 
+  it('should throw an error when a value is empty when empty values are disallowed', function() {
+    data.biography = '';
+    t.throw(jsonTemplate(JSON.stringify(tmpl), {disallowEmpty: true}).bind(data), /Empty value for key `\S+`/);
+  });
+
+  it('should not throw an error when a value is empty when empty values are not disallowed', function() {
+    data.biography = '';
+    t.deepEqual(JSON.parse(jsonTemplate(JSON.stringify(tmpl))(data)), {
+      'user': {
+        'age': 25,
+        'biography': '{{biography}}',
+        'hasBlueEyes': true
+      }
+    });
+  });
+
   it('should throw an error when a key is missing in strict mode', function() {
     t.throw(jsonTemplate(JSON.stringify(tmpl), {strictMode: true}).bind({}), /Missing key `\S+`/);
   });


### PR DESCRIPTION
When a value is empty, no error thrown but tag is not replaced by the empty value.
To keep actual behaviour and to open the possibilities, I add a new option to manage this case.